### PR TITLE
added language translations for fresh carrion spotted message from 1.4

### DIFF
--- a/1.5/Languages/Catalan (Català)/Keyed/Messages.xml
+++ b/1.5/Languages/Catalan (Català)/Keyed/Messages.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<LanguageData>
+  <FreshCarrionSpotted>Un animal mort: {0}</FreshCarrionSpotted>
+</LanguageData>

--- a/1.5/Languages/ChineseSimplified (简体中文)/Keyed/Messages.xml
+++ b/1.5/Languages/ChineseSimplified (简体中文)/Keyed/Messages.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<LanguageData>
+  <FreshCarrionSpotted>死动物: {0}</FreshCarrionSpotted>
+</LanguageData>

--- a/1.5/Languages/ChineseTraditional (繁體中文)/Keyed/Messages.xml
+++ b/1.5/Languages/ChineseTraditional (繁體中文)/Keyed/Messages.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<LanguageData>
+  <FreshCarrionSpotted>死動物: {0}</FreshCarrionSpotted>
+</LanguageData>

--- a/1.5/Languages/Czech (Čeština)/Keyed/Messages.xml
+++ b/1.5/Languages/Czech (Čeština)/Keyed/Messages.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<LanguageData>
+  <FreshCarrionSpotted>Mrtvé zvíře: {0}</FreshCarrionSpotted>
+</LanguageData>

--- a/1.5/Languages/Danish (Dansk)/Keyed/Messages.xml
+++ b/1.5/Languages/Danish (Dansk)/Keyed/Messages.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<LanguageData>
+  <FreshCarrionSpotted>Et dødt dyr: {0}</FreshCarrionSpotted>
+</LanguageData>

--- a/1.5/Languages/Dutch (Nederlands)/Keyed/Messages.xml
+++ b/1.5/Languages/Dutch (Nederlands)/Keyed/Messages.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<LanguageData>
+  <FreshCarrionSpotted>Een dood dier: {0}</FreshCarrionSpotted>
+</LanguageData>

--- a/1.5/Languages/English/Keyed/Messages.xml
+++ b/1.5/Languages/English/Keyed/Messages.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<LanguageData>
+  <FreshCarrionSpotted>Fresh carrion spotted: {0}</FreshCarrionSpotted>
+</LanguageData>

--- a/1.5/Languages/Estonian (Eesti)/Keyed/Messages.xml
+++ b/1.5/Languages/Estonian (Eesti)/Keyed/Messages.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<LanguageData>
+  <FreshCarrionSpotted>Surnud loom: {0}</FreshCarrionSpotted>
+</LanguageData>

--- a/1.5/Languages/Finnish (Suomi)/Keyed/Messages.xml
+++ b/1.5/Languages/Finnish (Suomi)/Keyed/Messages.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<LanguageData>
+  <FreshCarrionSpotted>Kuollut eläin: {0}</FreshCarrionSpotted>
+</LanguageData>

--- a/1.5/Languages/French (Français)/Keyed/Messages.xml
+++ b/1.5/Languages/French (Français)/Keyed/Messages.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<LanguageData>
+  <FreshCarrionSpotted>Un animal mort: {0}</FreshCarrionSpotted>
+</LanguageData>

--- a/1.5/Languages/German (Deutsch)/Keyed/Messages.xml
+++ b/1.5/Languages/German (Deutsch)/Keyed/Messages.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<LanguageData>
+  <FreshCarrionSpotted>Totes Tier: {0}</FreshCarrionSpotted>
+</LanguageData>

--- a/1.5/Languages/Greek (Ελληνικά)/Keyed/Messages.xml
+++ b/1.5/Languages/Greek (Ελληνικά)/Keyed/Messages.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<LanguageData>
+  <FreshCarrionSpotted>Ένα νεκρό ζώο: {0}</FreshCarrionSpotted>
+</LanguageData>

--- a/1.5/Languages/Hungarian (Magyar)/Keyed/Messages.xml
+++ b/1.5/Languages/Hungarian (Magyar)/Keyed/Messages.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<LanguageData>
+  <FreshCarrionSpotted>Döglött állat: {0}</FreshCarrionSpotted>
+</LanguageData>

--- a/1.5/Languages/Italian (Italiano)/Keyed/Messages.xml
+++ b/1.5/Languages/Italian (Italiano)/Keyed/Messages.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<LanguageData>
+  <FreshCarrionSpotted>Un animale morto: {0}</FreshCarrionSpotted>
+</LanguageData>

--- a/1.5/Languages/Japanese (日本語)/Keyed/Messages.xml
+++ b/1.5/Languages/Japanese (日本語)/Keyed/Messages.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<LanguageData>
+  <FreshCarrionSpotted>死んだ動物: {0}</FreshCarrionSpotted>
+</LanguageData>

--- a/1.5/Languages/Korean (한국어)/Keyed/Messages.xml
+++ b/1.5/Languages/Korean (한국어)/Keyed/Messages.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<LanguageData>
+  <FreshCarrionSpotted>죽은 동물: {0}</FreshCarrionSpotted>
+</LanguageData>

--- a/1.5/Languages/Norwegian (Norsk Bokmål)/Keyed/Messages.xml
+++ b/1.5/Languages/Norwegian (Norsk Bokmål)/Keyed/Messages.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<LanguageData>
+  <FreshCarrionSpotted>Et dødt dyr: {0}</FreshCarrionSpotted>
+</LanguageData>

--- a/1.5/Languages/Polish (Polski)/Keyed/Messages.xml
+++ b/1.5/Languages/Polish (Polski)/Keyed/Messages.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<LanguageData>
+  <FreshCarrionSpotted>Świeża padlina: {0}</FreshCarrionSpotted>
+</LanguageData>

--- a/1.5/Languages/Portuguese (Português)/Keyed/Messages.xml
+++ b/1.5/Languages/Portuguese (Português)/Keyed/Messages.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<LanguageData>
+  <FreshCarrionSpotted>Um animal morto: {0}</FreshCarrionSpotted>
+</LanguageData>

--- a/1.5/Languages/Romanian (Română)/Keyed/Messages.xml
+++ b/1.5/Languages/Romanian (Română)/Keyed/Messages.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<LanguageData>
+  <FreshCarrionSpotted>Un animal mort: {0}</FreshCarrionSpotted>
+</LanguageData>

--- a/1.5/Languages/Russian (Русский)/Keyed/Messages.xml
+++ b/1.5/Languages/Russian (Русский)/Keyed/Messages.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<LanguageData>
+  <FreshCarrionSpotted>Мертвое животное: {0}</FreshCarrionSpotted>
+</LanguageData>

--- a/1.5/Languages/Slovak (Slovenčina)/Keyed/Messages.xml
+++ b/1.5/Languages/Slovak (Slovenčina)/Keyed/Messages.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<LanguageData>
+  <FreshCarrionSpotted>Mŕtve zviera: {0}</FreshCarrionSpotted>
+</LanguageData>

--- a/1.5/Languages/Spanish (Español(Castellano))/Keyed/Messages.xml
+++ b/1.5/Languages/Spanish (Español(Castellano))/Keyed/Messages.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<LanguageData>
+  <FreshCarrionSpotted>Animal muerto: {0}</FreshCarrionSpotted>
+</LanguageData>

--- a/1.5/Languages/Swedish (Svenska)/Keyed/Messages.xml
+++ b/1.5/Languages/Swedish (Svenska)/Keyed/Messages.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<LanguageData>
+  <FreshCarrionSpotted>Ett dött djur: {0}</FreshCarrionSpotted>
+</LanguageData>

--- a/1.5/Languages/Turkish (Türkçe)/Keyed/Messages.xml
+++ b/1.5/Languages/Turkish (Türkçe)/Keyed/Messages.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<LanguageData>
+  <FreshCarrionSpotted>Ölü bir hayvan: {0}</FreshCarrionSpotted>
+</LanguageData>

--- a/1.5/Languages/Ukrainian (Українська)/Keyed/Messages.xml
+++ b/1.5/Languages/Ukrainian (Українська)/Keyed/Messages.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<LanguageData>
+  <FreshCarrionSpotted>Мертва тварина: {0}</FreshCarrionSpotted>
+</LanguageData>


### PR DESCRIPTION
fixed notification translation 'error' when fresh carrion is spotted.